### PR TITLE
ci: fix deploy site publish pipeline for Playwright

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Validate vault quality gates
         run: pnpm run validate
 
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium
+
       - name: Setup uv
         uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3
         with:
@@ -92,9 +95,6 @@ jobs:
           ASTRO_BASE: ${{ steps.pages-url.outputs.base }}
           VAULT_NOTEBOOKS_PATH: ${{ vars.VAULT_NOTEBOOKS_PATH || 'lab' }}
           VAULT_SITE_REQUIRE_NOTEBOOKS: "1"
-
-      - name: Install Playwright browser
-        run: pnpm exec playwright install chromium
 
       - name: Smoke responsive site and Lab
         run: node scripts/smoke_responsive.mjs


### PR DESCRIPTION
ci: install Playwright browser in Deploy Site before validate

- Deploy Site was failing validate on main because `site:graph-smoke` expects Chromium before running.
- Added a single browser-install step before `pnpm run validate` in `.github/workflows/deploy-site.yml`.
