### PR TITLE
ci: ensure Playwright before deploy validate

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -46,11 +46,11 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Validate vault quality gates
-        run: pnpm run validate
-
       - name: Install Playwright browsers
         run: pnpm exec playwright install chromium
+
+      - name: Validate vault quality gates
+        run: pnpm run validate
 
       - name: Setup uv
         uses: astral-sh/setup-uv@5a7eac68fb9809dea845d802897dc5c723910fa3 # v7.1.3


### PR DESCRIPTION
ci: ensure Playwright is installed before deploy validation.

Deploy Site was still failing because validation (`pnpm run validate`) invokes graph smoke tests which require Chromium before the install step.

This move makes Playwright available before validate and avoids false negatives in site publish workflow.
