### PR TITLE
fix(site): simplify homepage cards and align release versioning

### DIFF
--- a/.changeset/rename-para-folders-pt-br.md
+++ b/.changeset/rename-para-folders-pt-br.md
@@ -1,5 +1,5 @@
 ---
-"digital-gardening-kit": major
+"digital-gardening-kit": minor
 ---
 
 Breaking change: pastas PARA renomeadas para português.

--- a/.site/pages/index.astro
+++ b/.site/pages/index.astro
@@ -87,15 +87,10 @@ const heroGraphHtml = graphHeroHtml();
       <article class="vault-card">
         <span class="vault-card__eyebrow">Local first</span>
         <h2 class="vault-card__title">Conhecimento que não depende da nuvem</h2>
-        <details class="vault-card__details">
-          <summary class="vault-card__body" aria-label="Resumo do card: conheça o texto completo para abrir">
-            Markdown puro e Git: funciona offline, em qualquer editor, sem lock-in.
-          </summary>
-          <p class="vault-card__body vault-card__body-full">
-            Markdown puro e Git: funciona offline, em qualquer editor, sem lock-in.
-            Repo privado ou público — você decide o que compartilhar, se é que vai compartilhar algo.
-          </p>
-        </details>
+        <p class="vault-card__body">
+          Markdown puro e Git: funciona offline, em qualquer editor, sem lock-in.
+          Repo privado ou público — você decide o que compartilhar, se é que vai compartilhar algo.
+        </p>
         <div class="vault-actions">
           <a class="vault-button vault-button--secondary" href={`${base}/meta-e-anexos/onboarding/entendendo-a-estrutura-de-pastas/`}>Estrutura</a>
         </div>
@@ -104,15 +99,10 @@ const heroGraphHtml = graphHeroHtml();
       <article class="vault-card">
         <span class="vault-card__eyebrow">AI-ready</span>
         <h2 class="vault-card__title">Agentes de IA como coautores</h2>
-        <details class="vault-card__details">
-          <summary class="vault-card__body" aria-label="Resumo do card: conheça o texto completo para abrir">
-            AGENTS.md, CLAUDE.md e GEMINI.md entregam contexto do vault a qualquer assistente.
-          </summary>
-          <p class="vault-card__body vault-card__body-full">
-            AGENTS.md, CLAUDE.md e GEMINI.md entregam contexto do vault a qualquer assistente.
-            Zero configuração extra para começar a usar IA no repositório.
-          </p>
-        </details>
+        <p class="vault-card__body">
+          AGENTS.md, CLAUDE.md e GEMINI.md entregam contexto do vault a qualquer assistente.
+          Zero configuração extra para começar a usar IA no repositório.
+        </p>
         <div class="vault-actions">
           <a class="vault-button vault-button--secondary" href={`${base}/meta-e-anexos/referencia/usando-com-agentes-de-ia/`}>Agentes</a>
         </div>
@@ -121,15 +111,10 @@ const heroGraphHtml = graphHeroHtml();
       <article class="vault-card">
         <span class="vault-card__eyebrow">Publicação opcional</span>
         <h2 class="vault-card__title">Site quando você quiser</h2>
-        <details class="vault-card__details">
-          <summary class="vault-card__body" aria-label="Resumo do card: conheça o texto completo para abrir">
-            GitHub Pages com Astro e Starlight. Escolha quais notas ficam públicas.
-          </summary>
-          <p class="vault-card__body vault-card__body-full">
-            GitHub Pages com Astro e Starlight. Escolha quais notas ficam públicas,
-            use seu domínio, ative RSS. Nada é publicado por padrão.
-          </p>
-        </details>
+        <p class="vault-card__body">
+          GitHub Pages com Astro e Starlight. Escolha quais notas ficam públicas,
+          use seu domínio, ative RSS. Nada é publicado por padrão.
+        </p>
         <div class="vault-actions">
           <a class="vault-button vault-button--secondary" href={`${base}/meta-e-anexos/workflows/publicando-seu-vault-como-site/`}>Publicar</a>
         </div>
@@ -138,14 +123,9 @@ const heroGraphHtml = graphHeroHtml();
       <article class="vault-card">
         <span class="vault-card__eyebrow">Conhecimento coletivo</span>
         <h2 class="vault-card__title">Documentação viva para times</h2>
-        <details class="vault-card__details">
-          <summary class="vault-card__body" aria-label="Resumo do card: conheça o texto completo para abrir">
-            Use Git, PRs e notas Markdown para manter decisões e guias auditáveis.
-          </summary>
-          <p class="vault-card__body vault-card__body-full">
-            Use Git, PRs e notas Markdown para manter decisões, recursos e guias em um lugar auditável.
-          </p>
-        </details>
+        <p class="vault-card__body">
+          Use Git, PRs e notas Markdown para manter decisões, recursos e guias em um lugar auditável.
+        </p>
         <div class="vault-actions">
           <a class="vault-button vault-button--secondary" href={`${base}/meta-e-anexos/referencia/convencoes-e-boas-praticas/`}>Convenções</a>
         </div>
@@ -154,14 +134,9 @@ const heroGraphHtml = graphHeroHtml();
       <article class="vault-card">
         <span class="vault-card__eyebrow">Lab</span>
         <h2 class="vault-card__title">Notebooks junto do vault</h2>
-        <details class="vault-card__details">
-          <summary class="vault-card__body" aria-label="Resumo do card: conheça o texto completo para abrir">
-            Use Marimo para tarefas locais de análise e transformação.
-          </summary>
-          <p class="vault-card__body vault-card__body-full">
-            Use Marimo para extract local, transformação e análises que não pertencem ao site estático.
-          </p>
-        </details>
+        <p class="vault-card__body">
+          Use Marimo para extract local, transformação e análises que não pertencem ao site estático.
+        </p>
         <div class="vault-actions">
           <a class="vault-button vault-button--secondary" href={`${base}/lab/`}>Abrir Lab</a>
         </div>
@@ -170,14 +145,9 @@ const heroGraphHtml = graphHeroHtml();
       <article class="vault-card">
         <span class="vault-card__eyebrow">Sindicação</span>
         <h2 class="vault-card__title">RSS para publicar e auditar fontes</h2>
-        <details class="vault-card__details">
-          <summary class="vault-card__body" aria-label="Resumo do card: conheça o texto completo para abrir">
-            Gere um feed aberto do seu vault e consuma fontes externas.
-          </summary>
-          <p class="vault-card__body vault-card__body-full">
-            Gere um feed aberto do seu vault e consuma feeds externos como snapshots analisáveis no Lab.
-          </p>
-        </details>
+        <p class="vault-card__body">
+          Gere um feed aberto do seu vault e consuma feeds externos como snapshots analisáveis no Lab.
+        </p>
         <div class="vault-actions">
           <a class="vault-button vault-button--secondary" href={`${base}/meta-e-anexos/workflows/publicando-e-consumindo-rss-no-vault/`}>Ver RSS</a>
         </div>
@@ -560,7 +530,7 @@ const heroGraphHtml = graphHeroHtml();
   .vault-home-section {
     --vault-card-min-height: auto;
     --vault-card-title-lines: 2;
-    --vault-card-body-lines: 3;
+    --vault-card-body-lines: 5;
     --vault-card-column-min: 20rem;
     margin-block: clamp(2rem, 4vw, 4rem);
   }
@@ -574,39 +544,10 @@ const heroGraphHtml = graphHeroHtml();
     height: auto;
   }
 
-  .vault-home-section .vault-card__details {
-    margin: 0;
-  }
-
-  .vault-home-section .vault-card__details > summary {
-    cursor: pointer;
-    list-style: none;
-    width: 100%;
-  }
-
-  .vault-home-section .vault-card__details > summary::marker,
-  .vault-home-section .vault-card__details > summary::-webkit-details-marker {
-    display: none;
-  }
-
-  .vault-home-section .vault-card__details > summary::after {
-    content: ' (ver mais)';
-    color: var(--sl-color-text-accent);
-    font-size: var(--sl-text-xs);
-    font-weight: 650;
-    white-space: nowrap;
-  }
-
-  .vault-home-section .vault-card__details[open] > summary::after {
-    content: ' (ver menos)';
-  }
-
-  .vault-home-section .vault-card__body-full {
-    display: block;
-    min-height: 0;
-    margin: 0.45rem 0 0;
+  .vault-home-section .vault-card__body {
     overflow: visible;
     -webkit-line-clamp: unset;
+    min-height: 0;
   }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digital-gardening-kit",
-  "version": "0.0.1",
+  "version": "0.2.11",
   "description": "Kit de ferramentas para a jardinagem digital",
   "private": true,
   "repository": {

--- a/scripts/release_package_smoke.test.js
+++ b/scripts/release_package_smoke.test.js
@@ -3,6 +3,26 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 
+test("root package.json version is aligned with the published release baseline", () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8"));
+  const version = pkg.version;
+
+  // 0.0.1 is the stale development placeholder from before changesets were wired up.
+  // After the first changeset version run the version must reflect the actual published state.
+  assert.notEqual(
+    version,
+    "0.0.1",
+    `package.json version is '0.0.1' — run 'pnpm changeset version' or restore the last published version.`,
+  );
+
+  // Must be a valid semver (major.minor.patch) so the release workflow can tag correctly.
+  assert.match(
+    version,
+    /^\d+\.\d+\.\d+$/,
+    `package.json version '${version}' is not a valid semver major.minor.patch string.`,
+  );
+});
+
 test("release package smoke keeps release and package publishing explicitly gated", async () => {
   const { buildReleasePackageSmokeReport } = await import("./release_package_smoke.mjs");
   const report = buildReleasePackageSmokeReport({ runPack: false });

--- a/scripts/site_ux_contract.test.js
+++ b/scripts/site_ux_contract.test.js
@@ -277,6 +277,28 @@ test('Accessibility foundations: skip link, lang, and license link are present',
   assert.match(astroConfig, /href: '\/LICENSE\.md'/);
 });
 
+test('Homepage cards render body text without interactive gating', () => {
+  const home = read('.site/pages/index.astro');
+  const css = read('.site/styles/custom.css');
+
+  // Body text must be in a plain <p>, never locked behind a <details> expand pattern.
+  assert.doesNotMatch(home, /class="vault-card__details"/);
+  assert.doesNotMatch(home, /vault-card__body-full/);
+  assert.doesNotMatch(home, /<summary[^>]*vault-card__body/);
+
+  // Each card section must contain a direct <p class="vault-card__body">.
+  const cardBodies = home.match(/<p class="vault-card__body">/g);
+  assert.ok(cardBodies && cardBodies.length >= 6, 'Expected at least 6 card body paragraphs in the homepage grid');
+
+  // The homepage section must override the global line-clamp so no body text is truncated.
+  assert.match(home, /vault-home-section[\s\S]*vault-card__body[\s\S]*-webkit-line-clamp:\s*unset/);
+  assert.match(home, /vault-home-section[\s\S]*vault-card__body[\s\S]*overflow:\s*visible/);
+
+  // The global component CSS defines the clamp variable; the homepage overrides it per-section.
+  assert.match(css, /--vault-card-body-lines/);
+  assert.match(css, /vault-card__body[\s\S]*-webkit-line-clamp: var\(--vault-card-body-lines\)/);
+});
+
 test('Package license fields align with LICENSE.md (GPL-3.0-only)', () => {
   const rootPkg = read('package.json');
   const cliPkg = read('packages/cli/package.json');


### PR DESCRIPTION
## Summary

- Remove `<details>/<summary>` pattern from homepage feature cards — body text is now always visible in a plain `<p>`
- Override `-webkit-line-clamp: unset` on `.vault-home-section .vault-card__body` so no body text is clipped
- Bump root `package.json` to `0.2.11` (aligns with the last published tag; the `0.0.1` was a stale placeholder from before changesets were wired up)
- Downgrade `rename-para-folders-pt-br` changeset from `major` to `minor` — pre-1.0 convention; produces `v0.3.0` on next release cycle

## New regression tests

Two contract tests guard against silent regressions going forward:

- **Homepage cards contract** (`site_ux_contract.test.js`): asserts `<p>` body (no `<details>` gate), ≥ 6 cards, homepage CSS overrides line-clamp to `unset`/`visible`
- **Release versioning baseline** (`release_package_smoke.test.js`): asserts root `package.json` is not the stale `0.0.1` placeholder and is valid semver

## Test plan

- [x] All unit/contract tests pass locally
- [x] Template CI passes on `develop`
- [ ] Template CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)