### PR TITLE
fix(ci): install Playwright before validate in prepare-release-pr

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium
+
       - name: Validate release candidate
         run: pnpm run validate
 


### PR DESCRIPTION
## Summary

The `prepare-release-pr` workflow runs `pnpm run validate` which includes `site:graph-smoke`. That smoke requires Chromium, but the workflow was missing the `playwright install chromium` step that exists in `template-ci.yml` and `ci.yml`.

## Test plan

- [x] Template CI passes on `develop`
- [x] Action pins check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)