### PR TITLE
fix(ci): install Playwright before validate in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install chromium
+
       - name: Validate release tree
         run: pnpm run validate
 


### PR DESCRIPTION
## Summary

`release.yml` runs `pnpm run validate` which includes `site:graph-smoke` and needs Chromium — same gap that was fixed in `prepare-release-pr` via #42. Caused the v0.3.0 release run to fail at the validate step before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)