### PR TITLE
feat(ci): add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: "Publish Release"
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` to `release.yml` so the release can be manually re-triggered from `main` when a workflow hotfix is merged after the release commit. Without this, `gh run rerun` uses the old workflow version (before the fix), and the push trigger doesn't fire again since the commit message no longer contains `chore(release):`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)