### PR TITLE
fix(ci): allow workflow_dispatch to bypass chore(release) commit gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     name: Create GitHub release
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.repository == 'aretw0/vault-seed' && contains(github.event.head_commit.message, 'chore(release):')
+    if: github.repository == 'aretw0/vault-seed' && (github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, 'chore(release):'))
 
     steps:
       - name: Checkout


### PR DESCRIPTION
`workflow_dispatch` events have no `head_commit`, so `contains(github.event.head_commit.message, 'chore(release):')` always evaluates to false and the job skips. Add `github.event_name == 'workflow_dispatch'` so manual dispatch runs the full release job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)