### PR TITLE
fix(ci): configure npm registry auth before changeset publish

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Setup Node.js with npm auth
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Setup
         uses: ./.github/actions/setup
         with:
@@ -32,4 +38,3 @@ jobs:
         run: pnpm changeset publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_REGISTRY: https://registry.npmjs.org/


### PR DESCRIPTION
`actions/setup-node` with `registry-url` writes `NODE_AUTH_TOKEN` into `~/.npmrc` so npm can authenticate. Without `registry-url`, `NODE_AUTH_TOKEN` in the env is ignored by npm and `pnpm changeset publish` gets `E404 Not Found` from `registry.npmjs.org` (unauthenticated PUT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)