### PR TITLE
perf(ci): cache Playwright browsers and enable uv cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Dependency cache trust mode. Use "off" for privileged publish/deploy jobs.
     required: false
     default: "auto"
+  install-playwright:
+    description: Install Playwright Chromium with browser cache.
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -42,3 +46,16 @@ runs:
       run: |
         set -euo pipefail
         pnpm install --frozen-lockfile
+
+    - name: Cache Playwright browsers
+      if: ${{ inputs.install-playwright == 'true' }}
+      id: playwright-cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-chromium-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+    - name: Install Playwright browsers
+      if: ${{ inputs.install-playwright == 'true' && steps.playwright-cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: pnpm exec playwright install chromium --with-deps

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Cache Playwright browsers
       if: ${{ inputs.install-playwright == 'true' }}
       id: playwright-cache
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/ms-playwright
         key: playwright-chromium-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,8 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium
+        with:
+          install-playwright: "true"
 
       - name: Validate vault quality gates
         run: pnpm run validate

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -45,9 +45,8 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium
+        with:
+          install-playwright: "true"
 
       - name: Validate vault quality gates
         run: pnpm run validate
@@ -56,6 +55,7 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.11.11"
+          enable-cache: true
 
       - name: Detect site URL and base path
         id: pages-url

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -40,9 +40,8 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium
+        with:
+          install-playwright: "true"
 
       - name: Validate release candidate
         run: pnpm run validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,8 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
-
-      - name: Install Playwright browsers
-        run: pnpm exec playwright install chromium
+        with:
+          install-playwright: "true"
 
       - name: Validate release tree
         run: pnpm run validate

--- a/.github/workflows/template-ci.yml
+++ b/.github/workflows/template-ci.yml
@@ -26,14 +26,14 @@ jobs:
 
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          install-playwright: "true"
 
       - name: Setup uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           version: "0.11.11"
-
-      - name: Install Playwright browser
-        run: pnpm exec playwright install chromium
+          enable-cache: true
 
       - name: Validate markdown and onboarding
         run: pnpm run validate


### PR DESCRIPTION
## Summary

- Add `install-playwright` input to `.github/actions/setup` (default `false`); when `true`, caches `~/.cache/ms-playwright` keyed by `pnpm-lock.yaml` hash so Chromium (~200MB) is downloaded only when the lockfile changes — not on every run
- Remove standalone `Install Playwright browsers` steps from `ci.yml`, `template-ci.yml`, `deploy-site.yml`, `prepare-release-pr.yml`, `release.yml` — now handled centrally by the setup action
- Add `enable-cache: true` to `setup-uv` in `template-ci.yml` and `deploy-site.yml` so Python deps are cached between runs

## Impact

- ~200MB of Chromium download cached per run (was downloaded fresh every CI run across 5 workflows)
- uv Python dependency cache enabled in both workflows that use uv
- Single place to update Playwright cache config going forward

## GitHub Packages note

Not implemented. The current packages (`@aretw0/dgk-cli`, `@aretw0/dgk-astro-plugins`, `dgk-lab-runtime`) are published to npm/PyPI — the public registries without auth friction for external consumers. GitHub Packages (npm registry) would add `.npmrc` auth requirements for any consumer, including agents-lab and refarm. GitHub Packages makes sense if/when Docker images are added to the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)