### PR TITLE
fix(ci): publish npm via changeset publish with provenance env

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -56,6 +56,7 @@ jobs:
         run: pnpm --filter @aretw0/dgk-astro-plugins build
 
       - name: Publish
-        run: pnpm changeset publish -- --provenance
+        run: pnpm changeset publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: ${{ vars.NPM_CONFIG_PROVENANCE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
         run: pnpm --filter @aretw0/dgk-astro-plugins build
 
       - name: Publish
-        run: pnpm changeset publish -- --provenance
+        run: pnpm changeset publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: ${{ vars.NPM_CONFIG_PROVENANCE }}

--- a/docs/processo-de-release.md
+++ b/docs/processo-de-release.md
@@ -67,6 +67,7 @@ Este processo é exclusivo para a manutenção do repositório `aretw0/vault-see
 5.  **Publicação Automática (template + pacotes npm):**
     *   O merge na `main` aciona o workflow **"Publish Release"** (`release.yml`).
     *   O workflow valida a árvore (`pnpm run validate`), cria a tag `vX.Y.Z`, publica a Release no GitHub com as notas extraídas do `CHANGELOG.md` e roda `pnpm changeset publish`. Esse último passo publica no npm os pacotes do workspace (`@aretw0/dgk-cli`, `@aretw0/dgk-channels`, `@aretw0/dgk-runner`, `@aretw0/dgk-skills`, `@aretw0/dgk-astro-plugins`) cuja versão ainda não existe no registry; pacotes já publicados são pulados (operação idempotente).
+    *   A publicação habilita [npm provenance](https://docs.npmjs.com/generating-provenance-statements) via a variável de repositório `NPM_CONFIG_PROVENANCE` (Settings → Secrets and variables → Actions → Variables), lida pelo npm como env var; o job concede `id-token: write` para a atestação. Não passe `--provenance` como argumento ao `changeset publish` — o `@changesets/cli` v2 rejeita o argumento e aborta a publicação.
 
 6.  **Publicação do pacote Python (`dgk-lab-runtime`):**
     *   O pacote PyPI **não** é versionado por changesets nem publicado pelo "Publish Release" — ele tem uma trilha de versionamento própria e manual.

--- a/scripts/release_package_smoke.mjs
+++ b/scripts/release_package_smoke.mjs
@@ -219,8 +219,14 @@ export function buildReleasePackageSmokeReport(options = {}) {
   if (!/softprops\/action-gh-release@[0-9a-f]{40}/.test(releaseWorkflow)) {
     blockers.push("release workflow must keep GitHub Release action pinned to a full SHA");
   }
-  if (!/pnpm changeset publish -- --provenance/.test(releaseWorkflow)) {
+  if (!/pnpm changeset publish/.test(releaseWorkflow)) {
     blockers.push("release workflow must publish npm packages directly after creating the GitHub Release");
+  }
+  if (/changeset publish\s+--\s+--provenance/.test(releaseWorkflow)) {
+    blockers.push("release workflow must not pass --provenance as a changeset arg (changesets v2 rejects it and aborts the publish); enable provenance via the NPM_CONFIG_PROVENANCE env var instead");
+  }
+  if (!/NPM_CONFIG_PROVENANCE:\s*\S/.test(releaseWorkflow)) {
+    blockers.push("release workflow must enable npm provenance via the NPM_CONFIG_PROVENANCE env (repo variable vars.NPM_CONFIG_PROVENANCE)");
   }
   if (!/id-token:\s*write/.test(releaseWorkflow)) {
     blockers.push("release workflow must grant id-token:write for npm provenance publishing");
@@ -236,6 +242,12 @@ export function buildReleasePackageSmokeReport(options = {}) {
   }
   if (!/pnpm changeset publish/.test(publishWorkflow)) {
     blockers.push("publish-packages workflow must publish via changesets");
+  }
+  if (/changeset publish\s+--\s+--provenance/.test(publishWorkflow)) {
+    blockers.push("publish-packages workflow must not pass --provenance as a changeset arg; enable provenance via the NPM_CONFIG_PROVENANCE env var instead");
+  }
+  if (!/NPM_CONFIG_PROVENANCE:\s*\S/.test(publishWorkflow)) {
+    blockers.push("publish-packages workflow must enable npm provenance via the NPM_CONFIG_PROVENANCE env (repo variable vars.NPM_CONFIG_PROVENANCE)");
   }
   if (!/pnpm --filter @aretw0\/dgk-astro-plugins build/.test(publishWorkflow)) {
     blockers.push("publish-packages workflow must build @aretw0/dgk-astro-plugins before npm publishing");


### PR DESCRIPTION
Corrige o comando de publish que abortava silenciosamente o changeset publish (changesets v2 rejeita `-- --provenance`), deixando a v0.4.0 sem publicar no npm apesar do job verde. Habilita provenance via NPM_CONFIG_PROVENANCE e atualiza o contrato release_package_smoke para travar a regressão.

Não contém 'chore(release):' no título, então o merge não dispara o Publish Release — ele será re-disparado manualmente (workflow_dispatch) após o merge.